### PR TITLE
SOUX-13790, SOUX-13793 Corrección horario al agendar cita o demo

### DIFF
--- a/src/main/java/resources/CommonSeekopUtilities.java
+++ b/src/main/java/resources/CommonSeekopUtilities.java
@@ -344,8 +344,9 @@ public class CommonSeekopUtilities {
             if (getConnectionDistribuidor().next()) {
                 this.idProspecto = validarvacio(getConnectionDistribuidor().getString("IdProspecto"), "");
                 this.idauto = validarvacio(getConnectionDistribuidor().getString("IdAuto"), "");
+                this.idEjecutivo = validarvacio(getConnectionDistribuidor().getString("idpropietario"), "");
                 buscarAutoProspecto(idauto);
-                buscarEjecutivo(validarvacio(getConnectionDistribuidor().getString("idpropietario"), ""));
+                buscarEjecutivo(idEjecutivo);
             } else {
                 setErrorMensaje("No se encontraron datos para el prospecto '" + idProspecto + "'");
             }


### PR DESCRIPTION
Corregir carga de ejecutivo y horario al agendar cita o demo (SOUX-13790, SOUX-13793)

Se asigna correctamente idEjecutivo antes de las consultas y se asegura que la búsqueda de autos y ejecutivos funcione, evitando que la carga de horarios se quede colgada al agendar citas o demos.